### PR TITLE
Precompute w to avoid recomputing it over and over

### DIFF
--- a/test/onedim/real_forward.jl
+++ b/test/onedim/real_forward.jl
@@ -17,7 +17,7 @@ end
 
     @testset "temporarily test real dft separately until used by rfft" begin
         y_dft = similar(y)
-        FFTA.fft_dft!(y_dft, x, n, 1, 1, 1, 1, FFTA.FFT_FORWARD)
+        FFTA.fft_dft!(y_dft, x, n, 1, 1, 1, 1, cispi(-2/n))
         @test y ≈ y_dft
     end
 end


### PR DESCRIPTION
This quantity only dependens on the size of the FFT and direction. At the time the callgraph is computed, we know the size but not the direction. However, changing the direction is only a matter of conjugation which is much cheaper than cispi which is used when computing w.

Here are some timings (I've included FFTW so we can see what we are up against)

## composite
### current
```julia
julia> @btime p*x setup=(x = complex.(randn(5^8)); p = plan_fft(x));
  33.310 ms (3 allocations: 5.96 MiB)
```
### new
```julia
julia> @btime p*x setup=(x = complex.(randn(5^8)); p = plan_fft(x));
  20.143 ms (3 allocations: 5.96 MiB)
```
### FFTW
```julia
julia> @btime p*x setup=(x = complex.(randn(5^8)); p = plan_fft(x));
  3.256 ms (3 allocations: 5.96 MiB)
```
## pow2
### current
```julia
julia> @btime p*x setup=(x = complex.(randn(2^15)); p = plan_fft(x));
  1.032 ms (3 allocations: 512.06 KiB)
```
### new
```julia
julia> @btime p*x setup=(x = complex.(randn(2^15)); p = plan_fft(x));
  838.959 μs (3 allocations: 512.06 KiB)
```
### FFTW
```julia
julia> @btime p*x setup=(x = complex.(randn(2^15)); p = plan_fft(x));
  267.708 μs (3 allocations: 512.06 KiB)
```
## pow3
### current
```julia
julia> @btime p*x setup=(x = complex.(randn(3^9)); p = plan_fft(x));
  462.500 μs (3 allocations: 307.69 KiB)
```
### new
```julia
julia> @btime p*x setup=(x = complex.(randn(3^9)); p = plan_fft(x));
  285.625 μs (3 allocations: 307.69 KiB)
```
### FFTW
```julia
julia> @btime p*x setup=(x = complex.(randn(3^9)); p = plan_fft(x));
  90.583 μs (3 allocations: 307.69 KiB)
```
## pow4
### current
```julia
julia> @btime p*x setup=(x = complex.(randn(2^16)); p = plan_fft(x));
  959.625 μs (3 allocations: 1.00 MiB)
```
### new
```julia
julia> @btime p*x setup=(x = complex.(randn(2^16)); p = plan_fft(x));
  861.917 μs (3 allocations: 1.00 MiB)
```
### FFTW
```julia
julia> @btime p*x setup=(x = complex.(randn(3^9)); p = plan_fft(x));
  90.583 μs (3 allocations: 307.69 KiB)
```