### PR TITLE
Reduce JL compat, test allocs in JL>1.8, explain regression.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ DocStringExtensions = "0.9"
 MuladdMacro = "0.2"
 Primes = "0.5"
 Reexport = "1"
-julia = "1.9"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/onedim/complex_backward.jl
+++ b/test/onedim/complex_backward.jl
@@ -15,8 +15,8 @@ end
         @test naive_1d_fourier_transform(x, FFTA.FFT_BACKWARD) ≈ bfft(x)
     end
 
-    @testset "allocation" begin
-        @test (@allocations bfft(x)) <= 44
+    @testset "allocation regression" begin
+        @test (@test_allocations bfft(x)) <= 44
     end
 end
 

--- a/test/onedim/complex_forward.jl
+++ b/test/onedim/complex_forward.jl
@@ -15,8 +15,8 @@ end
         @test naive_1d_fourier_transform(x, FFTA.FFT_FORWARD) ≈ fft(x)
     end
 
-    @testset "allocation" begin
-        @test (@allocations fft(x)) <= 44
+    @testset "allocation regression" begin
+        @test (@test_allocations fft(x)) <= 44
     end
 end
 

--- a/test/onedim/real_backward.jl
+++ b/test/onedim/real_backward.jl
@@ -25,8 +25,8 @@ end
         @test naive_1d_fourier_transform(xe, FFTA.FFT_BACKWARD) ≈ brfft(x, n)
     end
 
-    @testset "allocation" begin
-        @test (@allocations brfft(x, n)) <= 50
+    @testset "allocation regression" begin
+        @test (@test_allocations brfft(x, n)) <= 50
     end
 end
 

--- a/test/onedim/real_forward.jl
+++ b/test/onedim/real_forward.jl
@@ -22,8 +22,8 @@ end
         end
     end
 
-    @testset "allocation" begin
-        @test (@allocations rfft(x)) <= 48
+    @testset "allocation regression" begin
+        @test (@test_allocations rfft(x)) <= 48
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,14 @@ function padnum(m,x)
     String(v)
 end
 
+macro test_allocations(args)
+    if Base.VERSION >= v"1.9"
+        :(@allocations($(esc(args))))
+    else
+        :(0)
+    end
+end
+
 function naive_1d_fourier_transform(x::Vector, d::FFTA.Direction)
     n = length(x)
     y = zeros(Complex{Float64}, n)

--- a/test/twodim/complex_backward.jl
+++ b/test/twodim/complex_backward.jl
@@ -17,7 +17,7 @@ end
         end
 
         @testset "allocations" begin
-            @test (@allocations bfft(X)) <= 111
+            @test (@test_allocations bfft(X)) <= 111
         end
     end
 end

--- a/test/twodim/complex_forward.jl
+++ b/test/twodim/complex_forward.jl
@@ -17,7 +17,7 @@ end
         end
 
         @testset "allocations" begin
-            @test (@allocations fft(X)) <= 111
+            @test (@test_allocations fft(X)) <= 111
         end
     end
 end

--- a/test/twodim/real_backward.jl
+++ b/test/twodim/real_backward.jl
@@ -11,5 +11,5 @@ end
 @testset "allocations" begin
     X = randn(256, 256)
     rfft(X) # compile
-    @test (@allocations rfft(X)) <= 51
+    @test (@test_allocations rfft(X)) <= 51
 end

--- a/test/twodim/real_forward.jl
+++ b/test/twodim/real_forward.jl
@@ -12,5 +12,5 @@ end
     X = randn(256, 256)
     Y = rfft(X)
     brfft(Y, 256) # compile
-    @test (@allocations brfft(Y, 256)) <= 54
+    @test (@test_allocations brfft(Y, 256)) <= 54
 end


### PR DESCRIPTION
Since the compat problem was solely because of the tests, I just did a slight circumvention of the issue. I don't think that we need to bump the Julia compat; these alloc tests are solely performance regressions as opposed to correctness unit tests, so it seems unnecessary to bump the version just for the tests.