### PR TITLE
Clean up imports and add tests with ExplicitImports.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,13 +15,15 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 [compat]
 AbstractFFTs = "1"
 DocStringExtensions = "0.9"
+ExplicitImports = "1.12"
 MuladdMacro = "0.2"
 Primes = "0.5"
 Reexport = "1"
 julia = "1.6"
 
 [extras]
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["ExplicitImports", "Test"]

--- a/src/FFTA.jl
+++ b/src/FFTA.jl
@@ -1,9 +1,13 @@
 module FFTA
 
-using Primes, DocStringExtensions, Reexport, MuladdMacro, LinearAlgebra
-@reexport using AbstractFFTs
+using AbstractFFTs: AbstractFFTs
+using DocStringExtensions: TYPEDSIGNATURES
+using LinearAlgebra: LinearAlgebra
+using MuladdMacro: @muladd
+using Primes: Primes
+using Reexport: @reexport
 
-import AbstractFFTs: Plan
+@reexport using AbstractFFTs
 
 include("callgraph.jl")
 include("algos.jl")

--- a/src/callgraph.jl
+++ b/src/callgraph.jl
@@ -85,12 +85,12 @@ function CallGraphNode!(nodes::Vector{CallGraphNode{T}}, N::Int, workspace::Vect
             return 1
         end
     end
-    if N == 1 || isprime(N)
+    if N == 1 || Primes.isprime(N)
         push!(workspace, T[])
         push!(nodes, CallGraphNode(0, 0, dft, N, s_in, s_out, w))
         return 1
     end
-    Ns = [first(x) for x in collect(factor(N)) for _ in 1:last(x)]
+    Ns = [first(x) for x in collect(Primes.factor(N)) for _ in 1:last(x)]
     if Ns[1] == 2
         N1 = prod(Ns[Ns .== 2])
     elseif Ns[1] == 3

--- a/src/plan.jl
+++ b/src/plan.jl
@@ -1,7 +1,4 @@
-import Base: *
-import LinearAlgebra: mul!
-
-abstract type FFTAPlan{T,N} <: Plan{T} end
+abstract type FFTAPlan{T,N} <: AbstractFFTs.Plan{T} end
 
 struct FFTAInvPlan{T,N} <: FFTAPlan{T,N} end
 
@@ -144,19 +141,19 @@ function _mul_loop(
     end
 end
 
-function *(p::FFTAPlan{T,1}, x::AbstractVector{T}) where {T<:Union{Real,Complex}}
+function Base.:*(p::FFTAPlan{T,1}, x::AbstractVector{T}) where {T<:Union{Real,Complex}}
     y = similar(x, T <: Real ? Complex{T} : T)
     LinearAlgebra.mul!(y, p, x)
     y
 end
 
-function *(p::FFTAPlan{T,N1}, x::AbstractArray{T,N2}) where {T<:Union{Real, Complex}, N1, N2}
+function Base.:*(p::FFTAPlan{T,N1}, x::AbstractArray{T,N2}) where {T<:Union{Real, Complex}, N1, N2}
     y = similar(x, T <: Real ? Complex{T} : T)
     LinearAlgebra.mul!(y, p, x)
     y
 end
 
-function *(p::FFTAPlan_re{T,1}, x::AbstractVector{T}) where {T<:Union{Real, Complex}}
+function Base.:*(p::FFTAPlan_re{T,1}, x::AbstractVector{T}) where {T<:Union{Real, Complex}}
     if p.dir == FFT_FORWARD
         y = similar(x, T <: Real ? Complex{T} : T)
         LinearAlgebra.mul!(y, p, x)
@@ -171,7 +168,7 @@ function *(p::FFTAPlan_re{T,1}, x::AbstractVector{T}) where {T<:Union{Real, Comp
     end
 end
 
-function *(p::FFTAPlan_re{T,N}, x::AbstractArray{T,2}) where {T<:Union{Real, Complex}, N}
+function Base.:*(p::FFTAPlan_re{T,N}, x::AbstractArray{T,2}) where {T<:Union{Real, Complex}, N}
     if p.dir == FFT_FORWARD
         y = similar(x, T <: Real ? Complex{T} : T)
         LinearAlgebra.mul!(y, p, x)

--- a/test/qa/explicit_imports.jl
+++ b/test/qa/explicit_imports.jl
@@ -1,0 +1,27 @@
+using FFTA, Test
+import ExplicitImports
+
+@testset "ExplicitImports" begin
+    # No implicit imports in FFTA (ie. no `using MyPkg`)
+    @test ExplicitImports.check_no_implicit_imports(FFTA) === nothing
+
+    # No non-owning imports in FFTA (ie. no `using LinearAlgebra: map`)
+    @test ExplicitImports.check_all_explicit_imports_via_owners(FFTA) === nothing
+
+    # No non-public imports in FFTA (ie. no `using MyPkg: _non_public_internal_func`)
+    @test ExplicitImports.check_all_explicit_imports_are_public(FFTA) === nothing
+
+    # No stale imports in FFTA (ie. no `using MyPkg: func` where `func` is not used in FFTA)
+    @test ExplicitImports.check_no_stale_explicit_imports(FFTA) === nothing
+
+    # No non-owning accesses in FFTA (ie. no `... LinearAlgebra.map(...)`)
+    @test ExplicitImports.check_all_qualified_accesses_via_owners(FFTA) === nothing
+
+    # No non-public accesses in FFTA (ie. no `... MyPkg._non_public_internal_func(...)`)
+    # AbstractFFTs requires subtyping of `Plan` but it is not public
+    # This is an upstream bug in AbstractFFTs.jl
+    @test ExplicitImports.check_all_qualified_accesses_are_public(FFTA; ignore = (:Plan,)) === nothing
+
+    # No self-qualified accesses in FFTA (ie. no `... FFTA.func(...)`)
+    @test ExplicitImports.check_no_self_qualified_accesses(FFTA) === nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,9 @@ end
 
 Random.seed!(1)
 @testset verbose = true "FFTA" begin
+    @testset verbose = true "QA" begin
+        include("qa/explicit_imports.jl")
+    end
     @testset verbose = true "1D" begin
         @testset verbose = false "Complex" begin
             include("onedim/complex_forward.jl")


### PR DESCRIPTION
The PR cleans the `import`/`using` statements to avoid implicit imports, and adds tests with https://github.com/JuliaTesting/ExplicitImports.jl.