### PR TITLE
Adjust allocation tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FFTA"
 uuid = "b86e33f2-c0db-4aa1-a6e0-ab43e668529e"
-authors = ["Danny Sharp <dannys4@mit.edu> and contributors"]
 version = "0.2.5"
+authors = ["Danny Sharp <dannys4@mit.edu> and contributors"]
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
@@ -16,8 +16,8 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 AbstractFFTs = "1"
 Aqua = "0.8"
 DocStringExtensions = "0.9"
-LinearAlgebra = "<0.0.1, 1"
 ExplicitImports = "1.12"
+LinearAlgebra = "<0.0.1, 1"
 MuladdMacro = "0.2"
 Primes = "0.5"
 Random = "<0.0.1, 1"

--- a/test/onedim/complex_backward.jl
+++ b/test/onedim/complex_backward.jl
@@ -16,7 +16,7 @@ end
     end
 
     @testset "allocation regression" begin
-        @test (@test_allocations bfft(x)) <= 44
+        @test (@test_allocations bfft(x)) <= 47
     end
 end
 

--- a/test/onedim/complex_forward.jl
+++ b/test/onedim/complex_forward.jl
@@ -18,7 +18,7 @@ end
     end
 
     @testset "allocation regression" begin
-        @test (@test_allocations fft(x)) <= 44
+        @test (@test_allocations fft(x)) <= 47
     end
 end
 

--- a/test/onedim/real_backward.jl
+++ b/test/onedim/real_backward.jl
@@ -26,7 +26,7 @@ end
     end
 
     @testset "allocation regression" begin
-        @test (@test_allocations brfft(x, n)) <= 50
+        @test (@test_allocations brfft(x, n)) <= 53
     end
 end
 

--- a/test/onedim/real_forward.jl
+++ b/test/onedim/real_forward.jl
@@ -25,7 +25,7 @@ end
     end
 
     @testset "allocation regression" begin
-        @test (@test_allocations rfft(x)) <= 48
+        @test (@test_allocations rfft(x)) <= 51
     end
 end
 

--- a/test/twodim/complex_backward.jl
+++ b/test/twodim/complex_backward.jl
@@ -17,7 +17,7 @@ end
         end
 
         @testset "allocations" begin
-            @test (@test_allocations bfft(X)) <= 111
+            @test (@test_allocations bfft(X)) <= 116
         end
     end
 end

--- a/test/twodim/complex_forward.jl
+++ b/test/twodim/complex_forward.jl
@@ -21,7 +21,7 @@ end
         end
 
         @testset "allocations" begin
-            @test (@test_allocations fft(X)) <= 111
+            @test (@test_allocations fft(X)) <= 116
         end
     end
 end

--- a/test/twodim/real_backward.jl
+++ b/test/twodim/real_backward.jl
@@ -12,5 +12,5 @@ end
     X = randn(256, 256)
     Y = rfft(X)
     brfft(Y, 256) # compile
-    @test (@test_allocations brfft(Y, 256)) <= 67
+    @test (@test_allocations brfft(Y, 256)) <= 68
 end

--- a/test/twodim/real_forward.jl
+++ b/test/twodim/real_forward.jl
@@ -16,5 +16,5 @@ end
 @testset "allocations" begin
     X = randn(256, 256)
     rfft(X) # compile
-    @test (@test_allocations rfft(X)) <= 61
+    @test (@test_allocations rfft(X)) <= 62
 end


### PR DESCRIPTION
It looks like more recent versions of Julia allocate a bit more when there is dynamical dispatch. Hence, the regression tests have to be bumped a bit.