### PR TITLE
Fix handling of custom element types and add tests

### DIFF
--- a/src/algos.jl
+++ b/src/algos.jl
@@ -18,8 +18,8 @@ function fft!(out::AbstractVector{T}, in::AbstractVector{T}, start_out::Int, sta
             if t === pow2FFT
                 fft_pow2!(out, in, N, start_out, s_out, start_in, s_in, _conj(root.w, d))
             elseif t === pow3FFT
-                p_120 = convert(T, cispi(2/3))
-                m_120 = convert(T, cispi(4/3))
+                p_120 = cispi(T(2)/3)
+                m_120 = cispi(T(4)/3)
                 _p_120, _m_120 = d == FFT_FORWARD ? (p_120, m_120) : (m_120, p_120)
                 fft_pow3!(out, in, N, start_out, s_out, start_in, s_in, _conj(root.w, d), _m_120, _p_120)
             elseif t === pow4FFT

--- a/src/callgraph.jl
+++ b/src/callgraph.jl
@@ -69,7 +69,7 @@ function CallGraphNode!(nodes::Vector{CallGraphNode{T}}, N::Int, workspace::Vect
     if N == 0
         throw(DimensionMismatch("array has to be non-empty"))
     end
-    w = convert(T, cispi(2/N))
+    w = cispi(T(2)/N)
     if iseven(N)
         pow = _ispow24(N)
         if !isnothing(pow)

--- a/test/custom_element_types.jl
+++ b/test/custom_element_types.jl
@@ -1,0 +1,27 @@
+using Test, FFTA
+
+x = randn(2*3*4*5)
+
+@testset "element type: $T" for T in  (Float16, BigFloat)
+    Tx = T.(x)
+
+    @testset "AbstractFFTs believes that single and double precision is everything." begin
+        # Ref https://github.com/JuliaMath/FFTA.jl/issues/77
+        if T == BigFloat
+            @test_broken fft(Tx)
+        else
+            @test_broken fft(Tx) isa Vector{Complex{T}}
+        end
+    end
+
+    # Complex
+    cTx = complex(Tx)
+    new_cTx = ifft(fft(cTx))
+    @test typeof(new_cTx) == typeof(cTx)
+    @test cTx ≈ new_cTx
+
+    # Real
+    new_Tx = irfft(rfft(Tx), length(Tx))
+    @test typeof(new_Tx) == typeof(Tx)
+    @test Tx ≈ new_Tx
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,4 +86,7 @@ Random.seed!(1)
             end
         end
     end
+    @testset verbose = true "Custom element types" begin
+        include("custom_element_types.jl")
+    end
 end


### PR DESCRIPTION
This is pretty cool
```julia
julia> x = randn(2*3*4*5);

julia> xb = big.(x);

julia> sum(abs2, ifft(fft(x)) - x)
1.0553991337729892e-27

julia> sum(abs2, ifft(fft(complex(xb))) - xb)
3.793342340231998013987487725586434854403317656598268138576734371348465548313345e-151
```

The base twiddle factors were computed with Float64 precision before conversion, so that had to be adjusted, but that was it.

However, #77 bites again

```julia
julia> fft(xb)
ERROR: type BigFloat not supported
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:44
 [2] _fftfloat(::Type{BigFloat})
   @ AbstractFFTs ~/.julia/packages/AbstractFFTs/4iQz5/src/definitions.jl:38
 [3] _fftfloat(x::BigFloat)
   @ AbstractFFTs ~/.julia/packages/AbstractFFTs/4iQz5/src/definitions.jl:39
 [4] fftfloat(x::BigFloat)
   @ AbstractFFTs ~/.julia/packages/AbstractFFTs/4iQz5/src/definitions.jl:34
 [5] complexfloat(x::Vector{BigFloat})
   @ AbstractFFTs ~/.julia/packages/AbstractFFTs/4iQz5/src/definitions.jl:47
 [6] fft(x::Vector{BigFloat}, region::UnitRange{Int64})
   @ AbstractFFTs ~/.julia/packages/AbstractFFTs/4iQz5/src/definitions.jl:214
 [7] fft(x::Vector{BigFloat})
   @ AbstractFFTs ~/.julia/packages/AbstractFFTs/4iQz5/src/definitions.jl:66
 [8] top-level scope
   @ REPL[22]:1
```