### PR TITLE
Add bounds checking

### DIFF
--- a/test/argument_checking.jl
+++ b/test/argument_checking.jl
@@ -1,0 +1,95 @@
+using Test, FFTA
+using LinearAlgebra: LinearAlgebra
+
+@testset "Only vectors and matrices" begin
+    xr = zeros(2, 2, 2)
+    xc = complex(xr)
+    @test_throws ArgumentError("only supports vectors and matrices") plan_fft(xc)
+    @test_throws ArgumentError("only supports vectors and matrices") plan_bfft(xc)
+    @test_throws ArgumentError("only supports vectors and matrices") plan_rfft(xr)
+    @test_throws ArgumentError("only supports vectors and matrices") plan_brfft(xc, 2)
+end
+
+@testset "Only 1D and 2D FFTs" begin
+    xr = zeros(2, 2)
+    xc = complex(xr)
+    @test_throws ArgumentError("only supports 1D and 2D FFTs") plan_fft(xc, 1:3)
+    @test_throws ArgumentError("only supports 1D and 2D FFTs") plan_bfft(xc, 1:3)
+    @test_throws ArgumentError("only supports 1D and 2D FFTs") plan_rfft(xr, 1:3)
+    @test_throws ArgumentError("only supports 1D and 2D FFTs") plan_brfft(xc, 2, 1:3)
+end
+
+@testset "mismatch between plan and array" begin
+    @testset "1D plan 1D array" begin
+        xr1 = randn(3)
+        yr1 = rfft(xr1)
+        xc1 = complex.(xr1)
+
+        xr1p = [xr1; 1]
+        xc1p = [xc1; 1]
+        yr1p = [yr1; 1]
+
+        @test_throws DimensionMismatch plan_fft(xc1) * xc1p
+        @test_throws DimensionMismatch plan_bfft(xc1) * xc1p
+        @test_throws DimensionMismatch plan_rfft(xr1) * xr1p
+        @test_throws DimensionMismatch plan_brfft(yr1, length(xr1)) * yr1p
+    end
+
+    @testset "2D array" begin
+        xr2 = randn(3, 3)
+        xc2 = complex.(xr2)
+
+        xr2p = [[xr2; ones(1, size(xr2, 2))] ones(size(xr2, 1) + 1, 1)]
+        xc2p = [[xc2; ones(1, size(xr2, 2))] ones(size(xc2, 1) + 1, 1)]
+
+        @testset "1D plan, region=$(region)" for region in [1, 2]
+            # Currently broken/not supported
+            @test_broken rfft(xr2, region)
+            # yr2 = rfft(xr2, region)
+
+            # yr2p = if region == 1
+            #     [yr2; ones(1, size(yr2, 2))]
+            # else
+            #     [yr2 ones(size(yr2, 1), 1)]
+            # end
+
+            @test_throws DimensionMismatch plan_fft(xc2, region) * xc2p
+            @test_throws DimensionMismatch plan_bfft(xc2, region) * xc2p
+            # @test_throws DimensionMismatch plan_rfft(xr2, region) * xr2p
+            # @test_throws DimensionMismatch plan_brfft(yr2, length(xr2), region) * yr2p
+        end
+
+        @testset "2D plan" begin
+            yr2 = rfft(xr2)
+
+            yr2p = [yr2; ones(1, 3)]
+
+            @test_throws DimensionMismatch plan_fft(xc2) * xc2p
+            @test_throws DimensionMismatch plan_bfft(xc2) * xc2p
+            @test_throws DimensionMismatch plan_rfft(xr2) * xr2p
+            @test_throws DimensionMismatch plan_brfft(yr2, size(xr2, 1)) * yr2p
+        end
+    end
+end
+
+@testset "mismatch besteen input and output arrays" begin
+    @testset "1D plan 1D array" begin
+        x1 = complex(randn(3))
+        y1 = similar(x1, length(x1) + 1)
+
+        @test_throws DimensionMismatch LinearAlgebra.mul!(y1, plan_fft(x1), x1)
+    end
+
+    @testset "2D array" begin
+        x2 = complex.(randn(3, 3), randn(3, 3))
+        y2 = similar(x2, size(x2, 1) + 1, size(x2, 2) + 1)
+
+        @testset "1D plan, region=$(region)" for region in [1, 2]
+            @test_throws DimensionMismatch LinearAlgebra.mul!(y2, plan_fft(x2, region), x2)
+        end
+
+        @testset "2D plan" begin
+            @test_throws DimensionMismatch LinearAlgebra.mul!(y2, plan_fft(x2), x2)
+        end
+    end
+end

--- a/test/qa/explicit_imports.jl
+++ b/test/qa/explicit_imports.jl
@@ -20,7 +20,7 @@ import ExplicitImports
     # No non-public accesses in FFTA (ie. no `... MyPkg._non_public_internal_func(...)`)
     # AbstractFFTs requires subtyping of `Plan` but it is not public
     # This is an upstream bug in AbstractFFTs.jl
-    @test ExplicitImports.check_all_qualified_accesses_are_public(FFTA; ignore = (:Plan, :require_one_based_indexing)) === nothing
+    @test ExplicitImports.check_all_qualified_accesses_are_public(FFTA; ignore = (:Plan, :require_one_based_indexing, :Fix1)) === nothing
 
     # No self-qualified accesses in FFTA (ie. no `... FFTA.func(...)`)
     @test ExplicitImports.check_no_self_qualified_accesses(FFTA) === nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,9 @@ Random.seed!(1)
         include("qa/aqua.jl")
         include("qa/explicit_imports.jl")
     end
+    @testset verbose = true "Argument checking" begin
+        include("argument_checking.jl")
+    end
     @testset verbose = true "1D" begin
         @testset verbose = true "Complex" begin
             @testset verbose = false "Forward" begin


### PR DESCRIPTION
Also, use ArgumentError for other incorrect inputs instead of `@assert`. Add tests for both.

See also the discussion in #84. Because of that bug, I'm now erroring out in the real case when the FFT is 1D and the array is 2D. As mentioned in the other issue, we need to decide on taking the FFTW "auto-vectorization" or the `mapslices` route, but let us discuss that in the other issues.

Update: notice that I ended up restricting the multiplication methods to only work for the complex case, and then explicitly convert the real plans to complex plans when applying the real plan. This was mostly to avoid some annoying interactions with AbstractFFTs, but I think it might also be cleaner.