### PR TITLE
Change region argument to be a tuple of integers

### DIFF
--- a/src/main.jl
+++ b/src/main.jl
@@ -1,15 +1,15 @@
-fft(X::AbstractArray{<:Complex}, region::Union{Int,AbstractVector} = 1:ndims(X)) = plan_fft(X, region) * X
-fft(X::AbstractArray, region::Union{Int,AbstractVector} = 1:ndims(X)) = fft(complex(X), region)
+fft(X::AbstractArray{<:Complex,N}, region::NTuple{D,Int} where D = ntuple(identity, N)) where N = plan_fft(X, region) * X
+fft(X::AbstractArray{<:Any,N}, region::NTuple{D,Int} where D = ntuple(identity, N)) where N = fft(complex(X), region)
 
-bfft(X::AbstractArray{<:Complex}, region::Union{Int,AbstractVector} = 1:ndims(X)) = plan_bfft(X, region) * X
+bfft(X::AbstractArray{<:Complex,N}, region::NTuple{D,Int} where D = ntuple(identity, N)) where N = plan_bfft(X, region) * X
 
-ifft(X::AbstractArray{<:Complex}, region::Union{Int,AbstractVector} = 1:ndims(X)) = bfft(X, region) / mapreduce(Base.Fix1(size, X), *, region; init=1)
+ifft(X::AbstractArray{<:Complex,N}, region::NTuple{D,Int} where D = ntuple(identity, N)) where N = bfft(X, region) / mapreduce(Base.Fix1(size, X), *, region; init=1)
 
-rfft(X::AbstractArray{<:Real}, region::Union{Int,AbstractVector} = 1:ndims(X)) = plan_rfft(X, region) * X
+rfft(X::AbstractArray{<:Real,N}, region::NTuple{D,Int} where D = ntuple(identity, N)) where N = plan_rfft(X, region) * X
 
-brfft(X::AbstractArray{<:Complex}, len::Int, region::Union{Int,AbstractVector} = 1:ndims(X)) = plan_brfft(X, len, region) * X
+brfft(X::AbstractArray{<:Complex,N}, len::Int, region::NTuple{D,Int} where D = ntuple(identity, N)) where N = plan_brfft(X, len, region) * X
 
-function irfft(X::AbstractArray{<:Complex}, len::Int, region::Union{Int,AbstractVector} = 1:ndims(X))
+function irfft(X::AbstractArray{<:Complex,N}, len::Int, region::NTuple{D,Int} where D = ntuple(identity, N)) where N
     Y = brfft(X, len, region)
     Y ./= mapreduce(Base.Fix1(size, Y), *, region; init=1)
     return Y

--- a/test/argument_checking.jl
+++ b/test/argument_checking.jl
@@ -4,10 +4,10 @@ using LinearAlgebra: LinearAlgebra
 @testset "Only 1D and 2D FFTs" begin
     xr = zeros(2, 2)
     xc = complex(xr)
-    @test_throws ArgumentError("only supports 1D and 2D FFTs") plan_fft(xc, 1:3)
-    @test_throws ArgumentError("only supports 1D and 2D FFTs") plan_bfft(xc, 1:3)
-    @test_throws ArgumentError("only supports 1D and 2D FFTs") plan_rfft(xr, 1:3)
-    @test_throws ArgumentError("only supports 1D and 2D FFTs") plan_brfft(xc, 2, 1:3)
+    @test_throws ArgumentError("only supports 1D and 2D FFTs") plan_fft(xc, (1, 2, 3))
+    @test_throws ArgumentError("only supports 1D and 2D FFTs") plan_bfft(xc, (1, 2, 3))
+    @test_throws ArgumentError("only supports 1D and 2D FFTs") plan_rfft(xr, (1, 2, 3))
+    @test_throws ArgumentError("only supports 1D and 2D FFTs") plan_brfft(xc, 2, (1, 2, 3))
 end
 
 @testset "mismatch between plan and array" begin
@@ -34,7 +34,7 @@ end
         xc2p = [[xc2; ones(1, size(xr2, 2))] ones(size(xc2, 1) + 1, 1)]
 
         @testset "1D plan, region=$(region)" for region in 1:2
-            yr2 = rfft(xr2, region)
+            yr2 = rfft(xr2, (region,))
 
             yr2p = if region == 1
                 [yr2; ones(1, size(yr2, 2))]
@@ -42,10 +42,10 @@ end
                 [yr2 ones(size(yr2, 1), 1)]
             end
 
-            @test_throws DimensionMismatch plan_fft(xc2, region) * xc2p
-            @test_throws DimensionMismatch plan_bfft(xc2, region) * xc2p
-            @test_throws DimensionMismatch plan_rfft(xr2, region) * xr2p
-            @test_throws DimensionMismatch plan_brfft(yr2, size(xr2, region), region) * yr2p
+            @test_throws DimensionMismatch plan_fft(xc2, (region,)) * xc2p
+            @test_throws DimensionMismatch plan_bfft(xc2, (region,)) * xc2p
+            @test_throws DimensionMismatch plan_rfft(xr2, (region,)) * xr2p
+            @test_throws DimensionMismatch plan_brfft(yr2, size(xr2, region), (region,)) * yr2p
         end
 
         @testset "2D plan" begin
@@ -74,7 +74,7 @@ end
         y2 = similar(x2, size(x2, 1) + 1, size(x2, 2) + 1)
 
         @testset "1D plan, region=$(region)" for region in [1, 2]
-            @test_throws DimensionMismatch LinearAlgebra.mul!(y2, plan_fft(x2, region), x2)
+            @test_throws DimensionMismatch LinearAlgebra.mul!(y2, plan_fft(x2, (region,)), x2)
         end
 
         @testset "2D plan" begin

--- a/test/onedim/complex_backward.jl
+++ b/test/onedim/complex_backward.jl
@@ -27,7 +27,7 @@ end
     x = complex.(randn(n, n + 1, n + 2), randn(n, n + 1, n + 2))
 
     @testset "against 1D array with mapslices, r=$r" for r in 1:3
-        @test bfft(x, r) == mapslices(bfft, x; dims = r)
+        @test bfft(x, (r,)) == mapslices(bfft, x; dims = r)
     end
 end
 

--- a/test/onedim/complex_forward.jl
+++ b/test/onedim/complex_forward.jl
@@ -6,8 +6,8 @@ using FFTA, Test
     y_ref = 0*y
     y_ref[1] = N
     @test y ≈ y_ref atol=1e-12
-    @test y == fft(reshape(x,1,1,N),3)[1,1,:]
-    @test y == fft(reshape(x,N,1), 1)[:,1]
+    @test y == fft(reshape(x, 1, 1, N), (3,))[1,1,:]
+    @test y == fft(reshape(x, N, 1), (1,))[:,1]
 end
 
 @testset "1D plan, 1D array. Size: $n" for n in 1:64
@@ -26,7 +26,7 @@ end
     x = complex.(randn(n, n + 1, n + 2), randn(n, n + 1, n + 2))
 
     @testset "against 1D array with mapslices, r=$r" for r in 1:3
-        @test fft(x, r) == mapslices(fft, x; dims = r)
+        @test fft(x, (r,)) == mapslices(fft, x; dims = r)
     end
 end
 

--- a/test/onedim/real_backward.jl
+++ b/test/onedim/real_backward.jl
@@ -31,12 +31,12 @@ end
     x = randn(n, n + 1, n + 2)
 
     @testset "round tripping with irfft, r=$r" for r in 1:3
-        @test irfft(rfft(x, r), size(x,r), r) ≈ x
+        @test irfft(rfft(x, (r,)), size(x, r), (r,)) ≈ x
     end
 
     @testset "against 1D array with mapslices, r=$r" for r in 1:3
-        y = rfft(x, r)
-        @test brfft(y, size(x, r), r) == mapslices(t -> brfft(t, size(x, r)), y; dims = r)
+        y = rfft(x, (r,))
+        @test brfft(y, size(x, r), (r,)) == mapslices(t -> brfft(t, size(x, r)), y; dims = r)
     end
 end
 

--- a/test/onedim/real_forward.jl
+++ b/test/onedim/real_forward.jl
@@ -6,8 +6,8 @@ using FFTA, Test
     y_ref = 0*y
     y_ref[1] = N
     @test y ≈ y_ref atol=1e-12
-    @test y == rfft(reshape(x,1,1,N),3)[1,1,:]
-    @test y == rfft(reshape(x,N,1),1)[:,1]
+    @test y == rfft(reshape(x, 1, 1, N), (3,))[1,1,:]
+    @test y == rfft(reshape(x, N, 1), (1,))[:,1]
 end
 
 @testset "1D plan, 1D array. Size: $n" for n in 1:64
@@ -33,7 +33,7 @@ end
     x = randn(n, n + 1, n + 2)
 
     @testset "against 1D array with mapslices, r=$r" for r in 1:3
-        @test rfft(x, r) == mapslices(rfft, x; dims = r)
+        @test rfft(x, (r,)) == mapslices(rfft, x; dims = r)
     end
 end
 

--- a/test/twodim/complex_backward.jl
+++ b/test/twodim/complex_backward.jl
@@ -27,8 +27,8 @@ end
 @testset "2D plan, ND array. Size: $n" for n in 1:64
     x = complex.(randn(n, n + 1, n + 2), randn(n, n + 1, n + 2))
 
-    @testset "against 1D array with mapslices, r=$r" for r in [[1,2], [1,3], [2,3]]
-        @test bfft(x, r) == mapslices(bfft, x; dims = r)
+    @testset "against 1D array with mapslices, r=$r" for r in [(1,2), (1,3), (2,3)]
+        @test bfft(x, r) == mapslices(bfft, x; dims = [r...])
     end
 end
 

--- a/test/twodim/complex_forward.jl
+++ b/test/twodim/complex_forward.jl
@@ -7,9 +7,9 @@ using FFTA, Test
     y_ref[1] = length(x)
     @test y ≈ y_ref
     x = randn(N,N)
-    @test fft(x) ≈ fft(reshape(x,1,N,N), [2,3])[1,:,:]
-    @test fft(x) ≈ fft(reshape(x,1,N,N,1), [2,3])[1,:,:,1]
-    @test fft(x) ≈ fft(reshape(x,1,1,N,N,1), [3,4])[1,1,:,:,1]
+    @test fft(x) ≈ fft(reshape(x, 1, N, N), (2, 3))[1,:,:]
+    @test fft(x) ≈ fft(reshape(x, 1, N, N, 1), (2, 3))[1,:,:,1]
+    @test fft(x) ≈ fft(reshape(x, 1, 1, N, N, 1), (3, 4))[1,1,:,:,1]
 end
 
 @testset "2D plan, 2D array. Size: $n" for n in 1:64
@@ -29,8 +29,8 @@ end
 @testset "2D plan, ND array. Size: $n" for n in 1:64
     x = complex.(randn(n, n + 1, n + 2), randn(n, n + 1, n + 2))
 
-    @testset "against 1D array with mapslices, r=$r" for r in [[1,2], [1,3], [2,3]]
-        @test fft(x, r) == mapslices(fft, x; dims = r)
+    @testset "against 1D array with mapslices, r=$r" for r in [(1,2), (1,3), (2,3)]
+        @test fft(x, r) == mapslices(fft, x; dims = [r...])
     end
 end
 

--- a/test/twodim/real_backward.jl
+++ b/test/twodim/real_backward.jl
@@ -27,13 +27,13 @@ end
 @testset "2D plan, ND array. Size: $n" for n in 1:64
     x = randn(n, n + 1, n + 2)
 
-    @testset "round trip with irfft, r=$r" for r in [[1,2], [1,3], [2,3]]
-        @test x ≈ irfft(rfft(x,r), size(x,r[1]), r)
+    @testset "round trip with irfft, r=$r" for r in [(1,2), (1,3), (2,3)]
+        @test x ≈ irfft(rfft(x, r), size(x, r[1]), r)
     end
 
-    @testset "against 2D array with mapslices, r=$r" for r in [[1,2], [1,3], [2,3]]
+    @testset "against 2D array with mapslices, r=$r" for r in [(1,2), (1,3), (2,3)]
         y = rfft(x, r)
-        @test brfft(y, size(x, r[1]), r) == mapslices(t -> brfft(t, size(x, r[1])), y; dims = r)
+        @test brfft(y, size(x, r[1]), r) == mapslices(t -> brfft(t, size(x, r[1])), y; dims = [r...])
     end
 end
 

--- a/test/twodim/real_forward.jl
+++ b/test/twodim/real_forward.jl
@@ -7,9 +7,9 @@ using FFTA, Test
     y_ref[1] = length(x)
     @test y ≈ y_ref
     x = randn(N,N)
-    @test rfft(x) ≈ rfft(reshape(x,1,N,N), [2,3])[1,:,:]
-    @test rfft(x) ≈ rfft(reshape(x,1,N,N,1), [2,3])[1,:,:,1]
-    @test rfft(x) ≈ rfft(reshape(x,1,1,N,N,1), [3,4])[1,1,:,:,1]
+    @test rfft(x) ≈ rfft(reshape(x ,1, N, N), (2, 3))[1,:,:]
+    @test rfft(x) ≈ rfft(reshape(x, 1, N, N, 1), (2, 3))[1,:,:,1]
+    @test rfft(x) ≈ rfft(reshape(x, 1, 1, N, N, 1), (3, 4))[1,1,:,:,1]
     @test size(rfft(x)) == (N÷2+1, N)
 end
 
@@ -30,8 +30,8 @@ end
 @testset "2D plan, ND array. Size: $n" for n in 1:64
     x = randn(n, n + 1, n + 2)
 
-    @testset "against 1D array with mapslices, r=$r" for r in [[1,2], [1,3], [2,3]]
-        @test rfft(x, r) == mapslices(rfft, x; dims = r)
+    @testset "against 1D array with mapslices, r=$r" for r in [(1,2), (1,3), (2,3)]
+        @test rfft(x, r) == mapslices(rfft, x; dims = [r...])
     end
 end
 


### PR DESCRIPTION
This makes everything fully inferred. The dimension of the FFT is simply the length of the tuple. Not sure if we want this, but wanted to check if it could work

So writing
```julia
fff(x, (1,))
fft(x, (2, 3))
```
instead of
```julia
fff(x, 1)
fft(x, 2:3)
```
will get you fully inferred results in return
```julia
julia> @inferred(rfft(randn(3)))
2-element Vector{ComplexF64}:
    1.10905148310797 + 0.0im
 -1.7099022373745139 + 0.3511562597656166im
```
Closes #78 