### PR TITLE
Extend power-of-2 benchmarks to 2^19 and 2^20

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -103,12 +103,12 @@ The benchmarks test various array sizes categorized by their mathematical struct
 
 ### Categories
 
-1. **Odd Powers of 2**: 2¹, 2³, 2⁵, 2⁷, 2⁹, 2¹¹, 2¹³, 2¹⁵
-   - Sizes: 2, 8, 32, 128, 512, 2048, 8192, 32768
+1. **Odd Powers of 2**: 2¹, 2³, 2⁵, 2⁷, 2⁹, 2¹¹, 2¹³, 2¹⁵, 2¹⁷, 2¹⁹
+   - Sizes: 2, 8, 32, 128, 512, 2048, 8192, 32768, 131072, 524288
    - Tests radix-2 FFT with odd exponents
 
-2. **Even Powers of 2**: 2², 2⁴, 2⁶, 2⁸, 2¹⁰, 2¹², 2¹⁴
-   - Sizes: 4, 16, 64, 256, 1024, 4096, 16384
+2. **Even Powers of 2**: 2², 2⁴, 2⁶, 2⁸, 2¹⁰, 2¹², 2¹⁴, 2¹⁶, 2¹⁸, 2²⁰
+   - Sizes: 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576
    - Tests radix-2 FFT with even exponents (often doubly-even cases)
 
 3. **Powers of 3**: 3¹, 3², 3³, 3⁴, 3⁵, 3⁶, 3⁷, 3⁸, 3⁹

--- a/benchmark/common_defs.jl
+++ b/benchmark/common_defs.jl
@@ -28,11 +28,11 @@ const SELECTED_PRIMES = begin
     sort!(selected)
 end
 
-# Odd powers of 2
-const ODD_POWERS_OF_2 = [2^i for i in 1:2:15]
+# Odd powers of 2 (up to 2^19 = 524288)
+const ODD_POWERS_OF_2 = [2^i for i in 1:2:19]
 
-# Even powers of 2
-const EVEN_POWERS_OF_2 = [2^i for i in 2:2:14]
+# Even powers of 2 (up to 2^20 = 1048576)
+const EVEN_POWERS_OF_2 = [2^i for i in 2:2:20]
 
 # Powers of 3
 const POWERS_OF_3 = [3^i for i in 1:9]


### PR DESCRIPTION
I'm preparing some performance improvements where I think it will be useful with slightly larger problems in the benchmark. They are still quite fast, so it doesn't add much to the CI time.

This is again Claude at work.

- Update ODD_POWERS_OF_2 range from 1:2:15 to 1:2:19
- Add 2^17 (131072) and 2^19 (524288) to odd powers
- Update EVEN_POWERS_OF_2 range from 2:2:16 to 2:2:20
- Add 2^18 (262144) and 2^20 (1048576) to even powers
- Update README.md to document the extended ranges
- Benchmarks now test powers of 2 from 2^1 to 2^20